### PR TITLE
add filtering cancelled events in recurrent events

### DIFF
--- a/src/utils/algorithms/handleDaily.js
+++ b/src/utils/algorithms/handleDaily.js
@@ -20,8 +20,16 @@ const handleDaily = (calendar, recurrence, e) => {
     : 1
   const n = wtfGoogle
   let add = wtfGoogle
-  let reoccurringEvents = [
-    {
+
+  // check if first event is cancelled
+  let isCancelled = cancelled.find(item => (
+      item.recurringEventId === e.id && start.isSame(item.originalStartTime.dateTime)
+  ));
+
+  // add first event if not cancelled
+  let reoccurringEvents = [];
+  if (!isCancelled) {
+    reoccurringEvents.push({
       eventType: calendar.name,
       creator: e.creator,
       end: end._d,
@@ -31,22 +39,29 @@ const handleDaily = (calendar, recurrence, e) => {
       start: start._d,
       title: e.summary,
       meta: e
-    }
-  ]
+    })
+  }
 
   while (recurrence > 0) {
-    const reoccurringEvent = {
-      eventType: calendar.name,
-      creator: e.creator,
-      end: end.clone().add(add, 'days')._d,
-      gLink: e.htmlLink,
-      description: e.description,
-      location: e.location,
-      start: start.clone().add(add, 'days')._d,
-      title: e.summary,
-      meta: e
+    // check if next events cancelled
+    let isCancelled = cancelled.find(item => (
+      item.recurringEventId === e.id && start.clone().add(add, "days").isSame(item.originalStartTime.dateTime)
+    ));
+
+    if (!isCancelled) {
+      const reoccurringEvent = {
+        eventType: calendar.name,
+        creator: e.creator,
+        end: end.clone().add(add, "days")._d,
+        gLink: e.htmlLink,
+        description: e.description,
+        location: e.location,
+        start: start.clone().add(add, "days")._d,
+        title: e.summary,
+        meta: e,
+      }
+      reoccurringEvents.push(reoccurringEvent)
     }
-    reoccurringEvents.push(reoccurringEvent)
     recurrence --
     add += n
   }

--- a/src/utils/algorithms/handleDateOfMonth.js
+++ b/src/utils/algorithms/handleDateOfMonth.js
@@ -14,34 +14,48 @@ const moment = require('moment')
      ? moment(e.start.date)
      : moment(e.end.dateTime)
 
-   let reoccurringEvents = [
-     {
-       eventType: calendar.name,
-       creator: e.creator,
-       end: end._d,
-       gLink: e.htmlLink,
-       description: e.description,
-       location: e.location,
-       start: start._d,
-       title: e.summary,
-       meta: e
-     }
-   ]
+    // check if first event is cancelled
+    let isCancelled = cancelled.find(item => (
+        item.recurringEventId === e.id && start.isSame(item.originalStartTime.dateTime)
+    ))
+
+    // add first event if not cancelled
+    let reoccurringEvents = [];
+    if (!isCancelled) {
+      reoccurringEvents.push({
+        eventType: calendar.name,
+        creator: e.creator,
+        end: end._d,
+        gLink: e.htmlLink,
+        description: e.description,
+        location: e.location,
+        start: start._d,
+        title: e.summary,
+        meta: e,
+      })
+    }
+
    let add = 1
 
    while (recurrence > 0) {
-     const reoccurringEvent = {
-       eventType: calendar.name,
-       creator: e.creator,
-       end: end.clone().add(add, 'months')._d,
-       gLink: e.htmlLink,
-       description: e.description,
-       location: e.location,
-       start: start.clone().add(add, 'months')._d,
-       title: e.summary,
-       meta: e
-     }
-     reoccurringEvents.push(reoccurringEvent)
+    let isCancelled = cancelled.find(item => (
+      item.recurringEventId === e.id && start.clone().add(add, "months").isSame(item.originalStartTime.dateTime)
+    ))
+
+    if (!isCancelled) {
+      const reoccurringEvent = {
+        eventType: calendar.name,
+        creator: e.creator,
+        start: start.clone().add(add, "months")._d,
+        end: end.clone().add(add, "months")._d,
+        gLink: e.htmlLink,
+        description: e.description,
+        location: e.location,
+        title: e.summary,
+        meta: e,
+      }
+      reoccurringEvents.push(reoccurringEvent);
+    }
      recurrence --
      add ++
    }

--- a/src/utils/algorithms/handleWeekly.js
+++ b/src/utils/algorithms/handleWeekly.js
@@ -6,7 +6,7 @@ const moment = require('moment')
  */
 
 // handleWeekly :: String -> Int -> {} -> [{}]
-const handleWeekly = (calendar, recurrence, e) => {
+const handleWeekly = (calendar, recurrence, e, cancelled) => {
   const start = e.start.date
     ? moment(e.start.date)
     : moment(e.start.dateTime)
@@ -14,8 +14,15 @@ const handleWeekly = (calendar, recurrence, e) => {
     ? moment(e.start.date)
     : moment(e.end.dateTime)
 
-  let reoccurringEvents = [
-    {
+  // check if first event is cancelled
+  let isCancelled = cancelled.find(item => (
+    item.recurringEventId === e.id && start.isSame(item.originalStartTime.dateTime)
+  ))
+
+  // add first event if not cancelled
+  let reoccurringEvents = [];
+  if (!isCancelled) {
+    reoccurringEvents.push({
       eventType: calendar.name,
       creator: e.creator,
       end: end._d,
@@ -24,24 +31,32 @@ const handleWeekly = (calendar, recurrence, e) => {
       location: e.location,
       start: start._d,
       title: e.summary,
-      meta: e
-    }
-  ]
+      meta: e,
+    })
+  }
+
   let add = 1
 
   while (recurrence > 0) {
-    const reoccurringEvent = {
-      eventType: calendar.name,
-      creator: e.creator,
-      end: end.clone().add(add, 'week')._d,
-      gLink: e.htmlLink,
-      description: e.description,
-      location: e.location,
-      start: start.clone().add(add, 'week')._d,
-      title: e.summary,
-      meta: e
+    // check if next events cancelled
+    let isCancelled = cancelled.find(item => (
+        item.recurringEventId === e.id && start.clone().add(add, "week").isSame(item.originalStartTime.dateTime)
+    ))
+
+    if (!isCancelled) {
+      const reoccurringEvent = {
+        eventType: calendar.name,
+        creator: e.creator,
+        end: end.clone().add(add, 'week')._d,
+        gLink: e.htmlLink,
+        description: e.description,
+        location: e.location,
+        start: start.clone().add(add, 'week')._d,
+        title: e.summary,
+        meta: e
+      }
+      reoccurringEvents.push(reoccurringEvent)
     }
-    reoccurringEvents.push(reoccurringEvent)
     recurrence --
     add ++
   }

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -38,11 +38,22 @@ const recurring = events => events.filter(item => item.recurrence)
   .map(event => ({ e: event, r: event.recurrence[0].split(';') }))
 
 // recurringByProperty :: [{}] -> Function -> String -> Int -> [{}]
-const recurringByProperty = (events, fn, calendar, occurences) => [].concat.apply([], events)
-  .map(event => fn(calendar, occurences, event))
+const recurringByProperty = (events, fn, calendar, occurences, cancelled) => [].concat.apply([], events)
+  .map(event => fn(calendar, occurences, event, cancelled))
 
 // removeCancelled :: [{}] -> [{}]
-const removeCancelled = events => events.filter(item => item.status != "cancelled")
+const removeCancelled = all => {
+  let events = []
+  let cancelled = []
+  for (let item of all) {
+    if (item.status === "cancelled") {
+      cancelled.push(item)
+    } else {
+      events.push(item)
+    }
+  }
+  return { events, cancelled }
+}
 
 // removeRecurrenceProperty :: [{}] -> [{}]
 const removeRecurrenceProperty = events => events.map(event => event.e)

--- a/src/utils/googleAPI.js
+++ b/src/utils/googleAPI.js
@@ -36,7 +36,7 @@ export default {
       .then(res => res.json())
       .then(res => {
         const items = res.items
-        const events = removeCancelled(items)
+        const { events, cancelled } = removeCancelled(items)
         const oneTimeEvents = oneTime(calendar, events)
         const recurringEvents = recurring(events)
 
@@ -45,7 +45,8 @@ export default {
           removeRecurrenceProperty(daily),
           handleDaily,
           calendar,
-          config.dailyRecurrence
+          config.dailyRecurrence,
+          cancelled
         ).flat()
 
         const weekly = filterByOneProperty("RRULE:FREQ=WEEKLY", recurringEvents)
@@ -53,7 +54,8 @@ export default {
           removeRecurrenceProperty(weekly),
           handleWeekly,
           calendar,
-          config.weeklyRecurrence
+          config.weeklyRecurrence,
+          cancelled
         ).flat()
 
         const monthly = filterByOneProperty("RRULE:FREQ=MONTHLY", recurringEvents)
@@ -69,13 +71,15 @@ export default {
           removeRecurrenceProperty(dateOfMonth),
           handleDateOfMonth,
           calendar,
-          config.monthlyRecurrence
+          config.monthlyRecurrence,
+          cancelled
         ).flat()
         const recurringDayOfMonth = recurringByProperty(
           removeRecurrenceProperty(dayOfMonth),
           handleDayOfMonth,
           calendar,
-          config.monthlyRecurrence
+          config.monthlyRecurrence,
+          cancelled
         ).flat()
 
         const allEvents = [].concat(


### PR DESCRIPTION
Cancelled events in recurrent events displayed as object in google api response:
```
  {
   "kind": "calendar#event",
   "etag": "\"316514750266000\"",
   "id": "cdj68cj6cgs4b9mckq62b9k6hh64b9pc8r38b9k6ee9l6ti3gc1jck_20200517T070000Z",
   "status": "cancelled",
   "recurringEventId": "cdj68cj6cgsj4b9mckq62b9k6hh64b9pc8r38b9k6ee9l6ti3gc1jck",
   "originalStartTime": {
    "dateTime": "2020-05-17T10:00:00+03:00"
   }
  }
```
So in current version they are filtered from api response and cancelled event in recurrent queue still shown.

Modification:
 - filtering cancelled events in separate array
 - check, if each new recurrent event is cancelled